### PR TITLE
fix: render tempalte load reset

### DIFF
--- a/gotests_test.go
+++ b/gotests_test.go
@@ -492,6 +492,7 @@ func TestGenerateTests(t *testing.T) {
 			name: "Entire testdata directory",
 			args: args{
 				srcPath: `testdata/`,
+				template: "testify",
 			},
 			wantMultipleTests: true,
 		}, {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -24,19 +24,24 @@ type Options struct {
 	TemplateData   [][]byte
 }
 
+func (o *Options) isProvidesTemplateData() bool { return o != nil && len(o.TemplateData) > 0 }
+func (o *Options) isProvidesTemplateDir() bool  { return o != nil && o.TemplateDir != "" }
+func (o *Options) isProvidesTemplate() bool     { return o != nil && o.Template != "" }
+
 func Process(head *models.Header, funcs []*models.Function, opt *Options) ([]byte, error) {
-	if opt != nil && opt.TemplateDir != "" {
-		err := render.LoadCustomTemplates(opt.TemplateDir)
-		if err != nil {
+	switch {
+	case opt.isProvidesTemplateDir():
+		if err := render.LoadCustomTemplates(opt.TemplateDir); err != nil {
 			return nil, fmt.Errorf("loading custom templates: %v", err)
 		}
-	} else if opt != nil && opt.Template != "" {
-		err := render.LoadCustomTemplatesName(opt.Template)
-		if err != nil {
+	case opt.isProvidesTemplate():
+		if err := render.LoadCustomTemplatesName(opt.Template); err != nil {
 			return nil, fmt.Errorf("loading custom templates of name: %v", err)
 		}
-	} else if opt != nil && opt.TemplateData != nil {
+	case opt.isProvidesTemplateData():
 		render.LoadFromData(opt.TemplateData)
+	default:
+		render.Reset()
 	}
 
 	tf, err := ioutil.TempFile("", "gotests_")

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,64 @@
+package output
+
+import "testing"
+
+func TestOptions_isProvidesTemplateData(t *testing.T) {
+	tests := []struct {
+		name    string
+		otpions *Options
+		want    bool
+	}{
+		{"Opt is nil", nil, false},
+		{"Opt is empty", &Options{}, false},
+		{"TemplateData is nil", &Options{TemplateData: nil}, false},
+		{"TemplateData is empty", &Options{TemplateData: [][]byte{}}, false},
+		{"TemplateData is OK", &Options{TemplateData: [][]byte{[]byte("ok")}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.otpions.isProvidesTemplateData(); got != tt.want {
+				t.Errorf("Options.isProvidesTemplateData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOptions_isProvidesTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		otpions *Options
+		want    bool
+	}{
+		{"Opt is nil", nil, false},
+		{"Opt is empty", &Options{}, false},
+		{"Template is empty (implicit_zero_val)", &Options{Template: ""}, false},
+		{"Template is OK", &Options{Template: "testify"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.otpions.isProvidesTemplate(); got != tt.want {
+				t.Errorf("Options.isProvidesTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOptions_isProvidesTemplateDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		otpions *Options
+		want    bool
+	}{
+		{"Opt is nil", nil, false},
+		{"Opt is empty", &Options{}, false},
+		{"Template is empty", &Options{TemplateDir: ""}, false},
+		{"Template is OK", &Options{TemplateDir: "testify"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.otpions.isProvidesTemplateDir(); got != tt.want {
+				t.Errorf("Options.isProvidesTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -24,6 +24,10 @@ var (
 )
 
 func init() {
+	Reset()
+}
+
+func Reset() {
 	initEmptyTmpls()
 	for _, name := range bindata.AssetNames() {
 		tmpls = template.Must(tmpls.Parse(bindata.FSMustString(false, name)))

--- a/testdata/goldens/interface_embedding.go
+++ b/testdata/goldens/interface_embedding.go
@@ -6,13 +6,13 @@ func TestSomeStruct_Do(t *testing.T) {
 	type fields struct {
 		Doer some.Doer
 	}
-	testCases := []struct {
+	tests := []struct {
 		name   string
 		fields fields
 	}{
 		// TODO: Add test cases.
 	}
-	for _, tt := range testCases {
+	for _, tt := range tests {
 		c := &SomeStruct{
 			Doer: tt.fields.Doer,
 		}


### PR DESCRIPTION
This fixes reset for render's template load, bug appears only while
running tests, when previous one is changing text one (if none of
the template* params provided).

Adds tests for output.Option checkers

Also fixes two tests:
1) Undefined Interface - solution fixed golden
2) Entire Directory - solution provide template name (testify).